### PR TITLE
Added wrapper around result (gotalk)

### DIFF
--- a/gotalk/gotalk.go
+++ b/gotalk/gotalk.go
@@ -223,3 +223,25 @@ func HandleBufferRequest(op string, ReqBufferHandler interface{}) {
 func HandleBufferNotification(op string, NotBufferHandler interface{}) {
 	gotalk.Call("handleBufferNotification", op, NotBufferHandler)
 }
+
+// Result is a wrapper for result and result.error
+type Result struct {
+	r *js.Object
+}
+
+// wrapper to support result and result.error
+func WrapResult(r *js.Object) Result {
+	return Result{
+		r: r,
+	}
+}
+
+// result(any)
+func (r Result) Result(args ...interface{}) {
+	r.r.Invoke(args...)
+}
+
+// result.error(any)
+func (r Result) Error(args ...interface{}) {
+	r.r.Get("error").Invoke(args...)
+}


### PR DESCRIPTION
This is regarding gotalk:

Added ```Result``` type, ```WrapResult``` func, ```Result.Result()```, ```Result.Error()```.  This allows the JavaScript client to send responses back to the server when the JS is hosting the request.

Example of use:

```
gotalk.Handle("greet", func(in string, out *js.Object) {
	console.log("You've been greeted: " + in)
	r := gotalk.WrapResult(out)
	if rand.Intn(1) == 1 {
		r.Result({"greeting": "Greetings and/or Salutations!"})
	} else {
		r.Error("Sir, I said Good Day.")
	}
})
```